### PR TITLE
Make it possible to install on ubuntu

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
     "url": "http://github.com/jbeard4"
   },
   "scripts": {
-    "preinstall": "npm install -g bower",
     "test": "cd SCXMLD-tests && npm install && cd .. && istanbul cover jasmine",
-    "postinstall": "bower install",
     "start": "node index.js"
   },
   "engines": {


### PR DESCRIPTION
Just following the instructions from the project page (as root):
```
# npm install -g scxmld

> scxmld@0.0.1-a preinstall /usr/lib/node_modules/scxmld
> npm install -g bower

npm ERR! Linux 3.13.0-46-generic
npm ERR! argv "node" "/usr/bin/npm" "install" "-g" "bower"
npm ERR! node v0.10.36
npm ERR! npm  v2.7.6
npm ERR! path /root/.npm/bower/1.4.1/package
npm ERR! code EACCES
npm ERR! errno 3
```

I've tried with or without a global bower, If I remove the preinstall line, then I can't run it in a root shell because postinst tries to run bower (still as root) because it's apparently a user command:

```
> bower install

bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes learning more about how your system should work and make any necessary repairs.

http://www.joyent.com/blog/installing-node-and-npm
https://gist.github.com/isaacs/579814

You can however run a command with sudo using --allow-root option
```
I'm not even sure the bower command should be run as root

If I check out the repo, remove both the preinst and the postinst, then run `sudo npm -g install --unsafe-perm` and then manually run bower install after installation, then it seems to work, I get a working `scxmld` command in my path.