### PR TITLE
libxmljs 0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "debug": "^2.1.3",
     "ejs": "^2.3.1",
     "express": "^4.12.3",
-    "libxmljs": "0.11.0",
+    "libxmljs": "0.14.1",
     "morgan": "^1.5.2",
     "redis": "^0.12.1",
     "scxml": "git://github.com/jbeard4/SCION.git#dd6465f58882e85ee2a599de9513662e453be21f",


### PR DESCRIPTION
On my machine, libxml 0.11.0 no longer builds, with iojs v1.8.1.
